### PR TITLE
Avoid to simlulate the existance of std.

### DIFF
--- a/esp32-sys/Cargo.toml
+++ b/esp32-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp32-sys"
-version = "0.1.0"
-edition = "2015"
+version = "0.2.0"
+edition = "2018"
 
 [dependencies]

--- a/esp32-sys/src/lib.rs
+++ b/esp32-sys/src/lib.rs
@@ -4,7 +4,6 @@
 #![allow(non_snake_case)]
 
 pub mod std {
-    pub use core::*;
     pub mod os {
         pub mod raw {
             pub enum c_void {}

--- a/esp32-sys/src/lib.rs
+++ b/esp32-sys/src/lib.rs
@@ -3,23 +3,19 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-pub mod std {
-    pub mod os {
-        pub mod raw {
-            pub enum c_void {}
-            pub type c_uchar = u8;
-            pub type c_schar = i8;
-            pub type c_char = i8;
-            pub type c_short = i16;
-            pub type c_ushort = u16;
-            pub type c_int = i32;
-            pub type c_uint = u32;
-            pub type c_long = i32;
-            pub type c_ulong = u32;
-            pub type c_longlong = i64;
-            pub type c_ulonglong = u64;
-        }
-    }
+pub mod libc {
+    pub enum c_void {}
+    pub type c_uchar = u8;
+    pub type c_schar = i8;
+    pub type c_char = i8;
+    pub type c_short = i16;
+    pub type c_ushort = u16;
+    pub type c_int = i32;
+    pub type c_uint = u32;
+    pub type c_long = i32;
+    pub type c_ulong = u32;
+    pub type c_longlong = i64;
+    pub type c_ulonglong = u64;
 }
 
 include!("bindings.rs");


### PR DESCRIPTION
The current version of `esp32-sys` is required to simulate the existance of `std::os::raw` as the bindings are generated without the `--cyptes-prefix` flag. Without this flag any libc related types are automatically imported via `::std::os::raw`.

This is also the reason why the `esp32-sys` crate couldn't be compiled with the `edition = "2018"` flag.

(see ctron/rust-esp-container#2 for the required change inside the template repository)